### PR TITLE
:recycle: Better handling of logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ etc.
 - Update-SteamServer
   - Fixed issue regarding the log file not being created due to a missing
   sub directory preventing any logging until the directory is created (#29).
+  - Fixed issue with the update workflow being corrupted if the server were online
+  at the beginning of the update (#30).
 
 ## [3.1.1] - 12/07-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Logging is now handled using *PSFramework* rather than the module *Logging*. Output
+of log files are now stored in CSV format with more information about the system
+etc.
+- Get-SteamServerInfo
+  - Write the error, if the server cannot be reached, instead of throwing it. This
+  is implemented because if the server could not be reached after using Update-SteamServer
+  the workflow would be terminated the first time the server could not be reached
+  instead of attempting to test it again.
+
+### Fixed
+
+- Update-SteamServer
+  - Fixed issue regarding the log file not being created due to a missing
+  sub directory preventing any logging until the directory is created (#29).
+
 ## [3.1.1] - 12/07-2020
 
 ### Fixed

--- a/SteamPS.depend.psd1
+++ b/SteamPS.depend.psd1
@@ -24,11 +24,11 @@
     'BuildHelpers'     = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'Configuration'    = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'InvokeBuild'      = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
-    'Logging'          = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'Pester'           = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'platyPS'          = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'posh-git'         = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'PSDeploy'         = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
+    'PSFramework'      = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'PSScriptAnalyzer' = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
     'powershell-yaml'  = @{ DependencyType = 'PSGalleryNuget'; version = 'latest' }
 }

--- a/SteamPS/Public/Server/Get-SteamServerInfo.ps1
+++ b/SteamPS/Public/Server/Get-SteamServerInfo.ps1
@@ -87,30 +87,32 @@
                 [System.Management.Automation.ErrorCategory]::ConnectionError,
                 $ReceivedData
             )
-            $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+            $PSCmdlet.WriteError($ErrorRecord)
         }
 
-        # This is also a header - that will always be equal to 'I' (0x49).
-        $Stream.ReadByte() | Out-Null
-
-        [PSCustomObject]@{
-            Protocol      = [int]$Stream.ReadByte()
-            ServerName    = Get-PacketString -Stream $Stream
-            Map           = Get-PacketString -Stream $Stream
-            InstallDir    = Get-PacketString -Stream $Stream
-            GameName      = Get-PacketString -Stream $Stream
-            AppID         = [int]$Stream.ReadUInt16()
-            Players       = [int]$Stream.ReadByte()
-            MaxPlayers    = [int]$Stream.ReadByte()
-            Bots          = $Stream.ReadByte()
-            ServerType    = [ServerType]$Stream.ReadByte()
-            Environment   = [OSType]$Stream.ReadByte()
-            Visibility    = [Visibility]$Stream.ReadByte()
-            VAC           = [VAC]$Stream.ReadByte()
-            Version       = Get-PacketString -Stream $Stream
-            ExtraDataFlag = $Stream.ReadByte()
-            IPAddress     = $IPAddress
-            Port          = $Port
-        } # PSCustomObject
+        # If we cannot reach the server we will not display the empty object.
+        if ($Stream) {
+            # This is also a header - that will always be equal to 'I' (0x49).
+            $Stream.ReadByte() | Out-Null
+            [PSCustomObject]@{
+                Protocol      = [int]$Stream.ReadByte()
+                ServerName    = Get-PacketString -Stream $Stream
+                Map           = Get-PacketString -Stream $Stream
+                InstallDir    = Get-PacketString -Stream $Stream
+                GameName      = Get-PacketString -Stream $Stream
+                AppID         = [int]$Stream.ReadUInt16()
+                Players       = [int]$Stream.ReadByte()
+                MaxPlayers    = [int]$Stream.ReadByte()
+                Bots          = $Stream.ReadByte()
+                ServerType    = [ServerType]$Stream.ReadByte()
+                Environment   = [OSType]$Stream.ReadByte()
+                Visibility    = [Visibility]$Stream.ReadByte()
+                VAC           = [VAC]$Stream.ReadByte()
+                Version       = Get-PacketString -Stream $Stream
+                ExtraDataFlag = $Stream.ReadByte()
+                IPAddress     = $IPAddress
+                Port          = $Port
+            } # PSCustomObject
+        }
     } # Process
 } # Cmdlet

--- a/SteamPS/Public/Server/Update-SteamServer.ps1
+++ b/SteamPS/Public/Server/Update-SteamServer.ps1
@@ -177,7 +177,7 @@
     end {
         if ($null -ne $DiscordWebhookUri -and ($ServerState -eq 'OFFLINE' -or $AlwaysNotify -eq $true)) {
             # Send Message to Discord about the update.
-            $ServerFact = New-DiscordFact -Name 'Game Server Info' -Value $(Get-SteamServerInfo -IPAddress $IPAddress -Port $Port | Select-Object -Property ServerName, IP, Port, Players | Out-String)
+            $ServerFact = New-DiscordFact -Name 'Game Server Info' -Value $(Get-SteamServerInfo -IPAddress $IPAddress -Port $Port -ErrorAction SilentlyContinue | Select-Object -Property ServerName, IP, Port, Players | Out-String)
             $ServerStateFact = New-DiscordFact -Name 'Server State' -Value $(Write-Output -InputObject "Server is $ServerState!")
             $LogFact = New-DiscordFact -Name 'Log Location' -Value "$LogPath\$ServiceName\$ServiceName-%Date%.csv"
             $Section = New-DiscordSection -Title "$ServiceName - Update Script Executed" -Facts $ServerStateFact, $ServerFact, $LogFact -Color $Color

--- a/SteamPS/Public/Server/Update-SteamServer.ps1
+++ b/SteamPS/Public/Server/Update-SteamServer.ps1
@@ -179,7 +179,7 @@
             # Send Message to Discord about the update.
             $ServerFact = New-DiscordFact -Name 'Game Server Info' -Value $(Get-SteamServerInfo -IPAddress $IPAddress -Port $Port | Select-Object -Property ServerName, IP, Port, Players | Out-String)
             $ServerStateFact = New-DiscordFact -Name 'Server State' -Value $(Write-Output -InputObject "Server is $ServerState!")
-            $LogFact = New-DiscordFact -Name 'Log Location' -Value $LogPath
+            $LogFact = New-DiscordFact -Name 'Log Location' -Value "$LogPath\$ServiceName\$ServiceName-%Date%.csv"
             $Section = New-DiscordSection -Title "$ServiceName - Update Script Executed" -Facts $ServerStateFact, $ServerFact, $LogFact -Color $Color
             Send-DiscordMessage -WebHookUrl $DiscordWebhookUri -Sections $Section
         }

--- a/SteamPS/Public/Server/Update-SteamServer.ps1
+++ b/SteamPS/Public/Server/Update-SteamServer.ps1
@@ -29,7 +29,7 @@
     Enter any additional arguments here.
 
     .PARAMETER LogPath
-    Specify the location of the log files.
+    Specify the directory of the log files.
 
     .PARAMETER DiscordWebhookUri
     Enter a Discord Webhook Uri if you wish to get notifications about the server
@@ -89,7 +89,7 @@
 
         [Parameter(Mandatory = $false)]
         [Alias('LogLocation')]
-        [string]$LogPath = "C:\DedicatedServers\Logs\$ServiceName\$($ServiceName)_$((Get-Date).ToShortDateString()).log",
+        [string]$LogPath = "C:\DedicatedServers\Logs",
 
         [Parameter(Mandatory = $false)]
         [string]$DiscordWebhookUri,
@@ -106,10 +106,15 @@
             throw 'SteamCMD could not be found in the env:Path. Have you executed Install-SteamCMD?'
         }
 
-        # Create a log file with information about the operation.
-        Set-LoggingDefaultLevel -Level 'INFO'
-        Add-LoggingTarget -Name Console
-        Add-LoggingTarget -Name File -Configuration @{ Path = $LogPath }
+        # Log settings
+        $PSFLoggingProvider = @{
+            Name          = 'logfile'
+            InstanceName  = '<taskname>'
+            FilePath      = "$LogPath\$ServiceName\$ServiceName-%Date%.csv"
+            Enabled       = $true
+            LogRotatePath = "$LogPath\$ServiceName\$ServiceName-*.csv"
+        }
+        Set-PSFLoggingProvider @PSFLoggingProvider
 
         # Variable that stores how many times the cmdlet has checked whether the
         # server is offline or online.
@@ -119,50 +124,51 @@
     process {
         # Get server status and output it.
         $ServerStatus = Get-SteamServerInfo -IPAddress $IPAddress -Port $Port
-        Write-Log -Message $ServerStatus
+        Write-PSFMessage -Level Host -Message $ServerStatus -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
 
         # Waiting to server is empty. Checking every 60 seconds.
         while ($ServerStatus.Players -ne 0) {
-            Write-Log -Message "Awaiting that the server is empty before updating."
+            Write-PSFMessage -Level Host -Message 'Awaiting that the server is empty before updating.' -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             $ServerStatus = Get-SteamServerInfo -IPAddress $IPAddress -Port $Port
-            Write-Log -Message $ServerStatus | Select-Object -Property ServerName, Port, Players
+            Write-PSFMessage -Level Host -Message $($ServerStatus | Select-Object -Property ServerName, Port, Players) -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             Start-Sleep -Seconds 60
         }
         # Server is now empty and we stop, update and start the server.
-        Write-Log -Message "Stopping $ServiceName"
+        Write-PSFMessage -Level Host -Message "Stopping $ServiceName" -Tag 'ServerUpdate' -ModuleName 'SteamPS' -Target $ServiceName
         Stop-Service -Name $ServiceName
-        Write-Log -Message "$($ServiceName): $((Get-Service -Name $ServiceName).Status)."
+        Write-PSFMessage -Level Host -Message "$($ServiceName): $((Get-Service -Name $ServiceName).Status)." -Tag 'ServerUpdate' -ModuleName 'SteamPS' -Target $ServiceName
 
-        Write-Log -Message "Updating $ServiceName..."
+        Write-PSFMessage -Level Host -Message "Updating $ServiceName..." -Tag 'ServerUpdate' -ModuleName 'SteamPS' -Target $ServiceName
         if ($null -ne $Credential) {
             Update-SteamApp -AppID $AppID -Path $Path -Credential $Credential -Arguments "$Arguments" -Force
         } else {
             Update-SteamApp -AppID $AppID -Path $Path -Arguments "$Arguments" -Force
         }
 
-        Write-Log -Message "Starting $ServiceName"
+        Write-PSFMessage -Level Host -Message "Starting $ServiceName" -Tag 'ServerUpdate' -ModuleName 'SteamPS' -Target $ServiceName
         Start-Service -Name $ServiceName
-        Write-Log -Message "$($ServiceName): $((Get-Service -Name $ServiceName).Status)."
+        Write-PSFMessage -Level Host -Message "$($ServiceName): $((Get-Service -Name $ServiceName).Status)." -Tag 'ServerUpdate' -ModuleName 'SteamPS' -Target $ServiceName
 
         do {
             $TimeoutCounter++ # Add +1 for every loop.
-            Write-Log -Message 'Waiting for server to come online again.'
+            Write-PSFMessage -Level Host -Message 'Waiting for server to come online again.' -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             Start-Sleep -Seconds 60
             # Getting new server information.
-            $ServerStatus = Get-SteamServerInfo -IPAddress $IPAddress -Port $Port | Select-Object -Property ServerName, Port, Players
-            Write-Log -Message $ServerStatus
-            Write-Log -Message "TimeoutCounter: $TimeoutCounter/$TimeoutLimit"
+            $ServerStatus = Get-SteamServerInfo -IPAddress $IPAddress -Port $Port -ErrorAction SilentlyContinue | Select-Object -Property ServerName, Port, Players
+            Write-PSFMessage -Level Host -Message $ServerStatus -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
+            Write-PSFMessage -Level Host -Message "No response from $($IPAddress):$($Port)." -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
+            Write-PSFMessage -Level Host -Message "TimeoutCounter: $TimeoutCounter/$TimeoutLimit" -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             if ($TimeoutCounter -ge $TimeoutLimit) {
                 break
             }
         } until ($null -ne $ServerStatus.ServerName)
 
         if ($null -ne $ServerStatus.ServerName) {
-            Write-Log -Message "$($ServerStatus.ServerName) is now ONLINE."
+            Write-PSFMessage -Level Host -Message "$($ServerStatus.ServerName) is now ONLINE." -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             $ServerState = 'ONLINE'
             $Color = 'Green'
         } else {
-            Write-Log -Level ERROR -Message "Server seems to be OFFLINE after the update..."
+            Write-PSFMessage -Level Critical -Message "Server seems to be OFFLINE after the update..." -Tag 'ServerStatus' -ModuleName 'SteamPS' -Target "$($IPAddress):$($Port)"
             $ServerState = 'OFFLINE'
             $Color = 'Red'
         }

--- a/SteamPS/SteamPS.psd1
+++ b/SteamPS/SteamPS.psd1
@@ -51,7 +51,7 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules   = @(@{ ModuleName = 'Logging'; GUID = '25a60f1d-85dd-4ad6-9efc-35fd3894f6c1'; ModuleVersion = '4.3.2' })
+    RequiredModules   = @(@{ ModuleName = 'PSFramework'; GUID = '8028b914-132b-431f-baa9-94a6952f21ff'; ModuleVersion = '1.4.149' })
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()


### PR DESCRIPTION
# PR Summary

This PR

- fixes #29
- fixes #30

## Context

Initially, I just wanted to create the folder that caused the lag of logging, but I also changed the logging functionality to use the [PSFramework](https://github.com/PowershellFrameworkCollective/psframework) rather than the logging module. The logging functionality in PSFramework also introduces functions such as rotation of logs.

## Changes

- Update-SteamServer: refactor to use PSFramework.
- Update-SteamServer: does not break if server, that is about to be updated, is offline when updating it.
- Get-SteamServerInfo: change so errors are just written rather than thrown and thus halting any further executions.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
