### PR TITLE
:bug: Remove the validate parameter when calling SteamCMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ etc.
   sub directory preventing any logging until the directory is created (#29).
   - Fixed issue with the update workflow being corrupted if the server were online
   at the beginning of the update (#30).
+- Update-SteamApp
+  - Remove the validate parameter when calling SteamCMD. Validation will overwrite
+  any files that have been changed. This may cause issues with customized
+  servers (#33).
 
 ## [3.1.1] - 12/07-2020
 

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -24,20 +24,20 @@ function Update-SteamApp {
 
     Beware, the following arguments are already used:
 
-    If you use Steam login to install/upload the app the following arguments are already used: "+login $SteamUserName $SteamPassword +force_install_dir $Path +app_update $SteamAppID $Arguments validate +quit"
+    If you use Steam login to install/upload the app the following arguments are already used: "+login $SteamUserName $SteamPassword +force_install_dir $Path +app_update $SteamAppID $Arguments +quit"
 
-    If you use anonymous login to install/upload the app the following arguments are already used: "+login anonymous +force_install_dir $Path +app_update $SteamAppID $Arguments validate +quit"
+    If you use anonymous login to install/upload the app the following arguments are already used: "+login anonymous +force_install_dir $Path +app_update $SteamAppID $Arguments +quit"
 
     .PARAMETER Force
     The Force parameter allows the user to skip the "Should Continue" box.
 
     .EXAMPLE
-    Update-SteamApp -ApplicationName 'Arma 3' -Credential 'Toby' -Path 'C:\Servers\Arma3'
+    Update-SteamApp -ApplicationName 'Arma 3' -Credential 'Toby' -Path 'C:\DedicatedServers\Arma3'
 
     Because there are multiple hits when searching for Arma 3, the user will be promoted to select the right application.
 
     .EXAMPLE
-    Update-SteamApp -AppID 376030 -Path 'C:\Servers'
+    Update-SteamApp -AppID 376030 -Path 'C:\DedicatedServers\ARK-SurvivalEvolved'
 
     Here we use anonymous login because the particular application (ARK: Survival Evolved Dedicated Server) doesn't require login.
 
@@ -110,7 +110,7 @@ function Update-SteamApp {
             # If Steam username and Steam password are not empty we use them for logging in.
             if ($null -ne $Credential.UserName) {
                 Write-Verbose -Message "Logging into Steam as $($Credential | Select-Object -ExpandProperty UserName)."
-                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login $($Credential.UserName) $($Credential.GetNetworkCredential().Password) +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments validate +quit" -Wait -PassThru
+                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login $($Credential.UserName) $($Credential.GetNetworkCredential().Password) +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
                 if ($SteamCMDProcess.ExitCode -ne 0) {
                     Write-Error -Message ("SteamCMD closed with ExitCode {0}" -f $SteamCMDProcess.ExitCode) -Category CloseError
                 }
@@ -118,7 +118,7 @@ function Update-SteamApp {
             # If Steam username and Steam password are empty we use anonymous login.
             elseif ($null -eq $Credential.UserName) {
                 Write-Verbose -Message 'Using SteamCMD as anonymous.'
-                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login anonymous +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments validate +quit" -Wait -PassThru
+                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login anonymous +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
                 if ($SteamCMDProcess.ExitCode -ne 0) {
                     Write-Error -Message ("SteamCMD closed with ExitCode {0}" -f $SteamCMDProcess.ExitCode) -Category CloseError
                 }


### PR DESCRIPTION
# PR Summary
As per default, SteamCMD in Update-SteamApp were set to validate. This could mean that customized files would get overwritten.

This fixes #33.

## Context

> Validate is a command that will check all the server files to make sure they match the SteamCMD files. This command is useful if you think that files may be missing or corrupted. Validation will overwrite any files that have been changed. This may cause issues with customized servers. For example, if you customize mapcycle.txt, this file will be overwritten to the server default. Any files that are not part of the default installation will not be affected.

> It is recommended you use this command only on initial installation and if there are server issues. 

Source: https://developer.valvesoftware.com/wiki/SteamCMD#Validate

## Changes

Update-SteamApp: Remove validate parameter from SteamCMD.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
