### PR TITLE
:recycle: Update CI configuration

### DIFF
--- a/.azure-pipelines/CI.yml
+++ b/.azure-pipelines/CI.yml
@@ -36,7 +36,7 @@ stages:
         strategy:
           matrix:
             Windows_Server2016_PowerShell_Core:
-              vmImage: vs2017-win2016
+              vmImage: windows-2022
             Windows_Server2019_PowerShell_Core:
               vmImage: windows-2019
         pool:
@@ -47,7 +47,7 @@ stages:
         strategy:
           matrix:
             Windows_Server2016_PowerShell_5_1:
-              vmImage: vs2017-win2016
+              vmImage: windows-2022
               pwsh: false
             Windows_Server2019_PowerShell_5_1:
               vmImage: windows-2019

--- a/.azure-pipelines/CI.yml
+++ b/.azure-pipelines/CI.yml
@@ -35,7 +35,7 @@ stages:
       - job:
         strategy:
           matrix:
-            Windows_Server2016_PowerShell_Core:
+            Windows_Server2022_PowerShell_Core:
               vmImage: windows-2022
             Windows_Server2019_PowerShell_Core:
               vmImage: windows-2019
@@ -46,7 +46,7 @@ stages:
       - job:
         strategy:
           matrix:
-            Windows_Server2016_PowerShell_5_1:
+            Windows_Server2022_PowerShell_5_1:
               vmImage: windows-2022
               pwsh: false
             Windows_Server2019_PowerShell_5_1:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,9 +140,9 @@ as dependency.
 
 - New workflow with AppVeyor.
 - Move `#Requires -RunAsAdministrator` statement from module file to the cmdlets
-that requires administrator priviliges (Install-SteamCMD, Update-SteamApp,
+that requires administrator privileges (Install-SteamCMD, Update-SteamApp,
 Update-SteamServer) allowing some cmdlets to be executed without administrator
-priviliges (Find-SteamAppID, Get-SteamServerInfo).
+privileges (Find-SteamAppID, Get-SteamServerInfo).
 - Use `$env:Path` instead of registry database to handle the install location of
 SteamCMD.
 

--- a/SteamPS.PSDeploy.ps1
+++ b/SteamPS.PSDeploy.ps1
@@ -3,7 +3,7 @@
         FromSource $env:BHProjectName
         To PSGallery
         WithOptions @{
-            ApiKey = $env:NuGetApiKey
+            ApiKey = $env:PSGalleryAPIKey
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ skip_commits:
   - .editorconfig
   - .azure-pipelines/*
 environment:
-  NuGetApiKey:
+  PSGalleryAPIKey:
     secure: rrhVkhM8VdtgWRj1yVok/pJyRmqKCiUhGQoEQqRKifm0CIpT9Bz8VuoDtWJVfKZw
   GitHubKey:
     secure: N7+lKlNrQkJHEtEtl1CcwG9Q3GRLbH9kGD41NWfb0GbLsH9rHjMoIiCVkDF8jolr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ skip_commits:
   - .azure-pipelines/*
 environment:
   PSGalleryAPIKey:
-    secure: rrhVkhM8VdtgWRj1yVok/pJyRmqKCiUhGQoEQqRKifm0CIpT9Bz8VuoDtWJVfKZw
+    secure: AhQDcc7fd1PVg8stMqWeeGnrrcZb/KcGxtBvcnmkT6hZekOIhaSNtmtX4g9kCqXk
   GitHubKey:
     secure: N7+lKlNrQkJHEtEtl1CcwG9Q3GRLbH9kGD41NWfb0GbLsH9rHjMoIiCVkDF8jolr
   SteamWebAPI:


### PR DESCRIPTION
# PR Summary

This PR updates configuration related to CI and other miscellaneous stuff. 

## Context



## Changes

- Update name of the environment variable that stores the API key for the PowerShell Gallery.
- Typos
- Update API key for the PowerShell gallery.
[-  Windows-2016 environment will be removed on March 15, 2022](https://github.com/actions/virtual-environments/issues/4312). Updated to 2022.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
