### PR TITLE
:recycle: Fix warning regarding force_install_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+- Update-SteamApp
+  - Fix warning SteamCMD displays about the force_install_dir parameter needs to
+  be called prior to the login parameter.
+
 ## [3.2.1] - 04/04-2021
 
 - Get-PacketString

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -26,7 +26,7 @@ function Update-SteamApp {
 
     If you use Steam login to install/upload the app the following arguments are already used: "+force_install_dir $Path +login $SteamUserName $SteamPassword +app_update $SteamAppID $Arguments +quit"
 
-    If you use anonymous login to install/upload the app the following arguments are already used: "+force_install_dir $Path +login anonymous+app_update $SteamAppID $Arguments +quit"
+    If you use anonymous login to install/upload the app the following arguments are already used: "+force_install_dir $Path +login anonymous +app_update $SteamAppID $Arguments +quit"
 
     .PARAMETER Force
     The Force parameter allows the user to skip the "Should Continue" box.

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -24,9 +24,9 @@ function Update-SteamApp {
 
     Beware, the following arguments are already used:
 
-    If you use Steam login to install/upload the app the following arguments are already used: "+login $SteamUserName $SteamPassword +force_install_dir $Path +app_update $SteamAppID $Arguments +quit"
+    If you use Steam login to install/upload the app the following arguments are already used: "+force_install_dir $Path +login $SteamUserName $SteamPassword +app_update $SteamAppID $Arguments +quit"
 
-    If you use anonymous login to install/upload the app the following arguments are already used: "+login anonymous +force_install_dir $Path +app_update $SteamAppID $Arguments +quit"
+    If you use anonymous login to install/upload the app the following arguments are already used: "+force_install_dir $Path +login anonymous+app_update $SteamAppID $Arguments +quit"
 
     .PARAMETER Force
     The Force parameter allows the user to skip the "Should Continue" box.
@@ -110,7 +110,7 @@ function Update-SteamApp {
             # If Steam username and Steam password are not empty we use them for logging in.
             if ($null -ne $Credential.UserName) {
                 Write-Verbose -Message "Logging into Steam as $($Credential | Select-Object -ExpandProperty UserName)."
-                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login $($Credential.UserName) $($Credential.GetNetworkCredential().Password) +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
+                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+force_install_dir `"$Path`" +login $($Credential.UserName) $($Credential.GetNetworkCredential().Password) +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
                 if ($SteamCMDProcess.ExitCode -ne 0) {
                     Write-Error -Message ("SteamCMD closed with ExitCode {0}" -f $SteamCMDProcess.ExitCode) -Category CloseError
                 }
@@ -118,7 +118,7 @@ function Update-SteamApp {
             # If Steam username and Steam password are empty we use anonymous login.
             elseif ($null -eq $Credential.UserName) {
                 Write-Verbose -Message 'Using SteamCMD as anonymous.'
-                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+login anonymous +force_install_dir `"$Path`" +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
+                $SteamCMDProcess = Start-Process -FilePath (Get-SteamPath).Executable -NoNewWindow -ArgumentList "+force_install_dir `"$Path`" +login anonymous +app_update $SteamAppID $Arguments +quit" -Wait -PassThru
                 if ($SteamCMDProcess.ExitCode -ne 0) {
                     Write-Error -Message ("SteamCMD closed with ExitCode {0}" -f $SteamCMDProcess.ExitCode) -Category CloseError
                 }


### PR DESCRIPTION
# PR Summary

Fixes #49

SteamCMD displays a warning about the parameter force_install_dir that should be called prior to the login parameter.

## Context

## Changes

- The parameter force_install_dir is called before the login parameter.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
