### PR TITLE
Fixes name property in output when no challenge is sent

### DIFF
--- a/SteamPS/Public/Server/Get-SteamServerInfo.ps1
+++ b/SteamPS/Public/Server/Get-SteamServerInfo.ps1
@@ -93,6 +93,8 @@
                 # The first 4 bytes are 255 which seems to be some sort of header.
                 $ReceivedData = $Client.Receive([Ref]$IPEndpoint) | Select-Object -Skip 4
                 $Stream = [System.IO.BinaryReader][System.IO.MemoryStream][Byte[]]$ReceivedData
+            } else {
+                $Stream.BaseStream.Position = 0
             }
 
             $Client.Close()


### PR DESCRIPTION
# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

As referenced in #51, this fixes the issue that causes server names to lose their first character in the output.

This was tested using your Windows server IP from #51 and my Linux server.

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

Since line 85 was moving the stream's read position, it needs to be moved back for when the output object is built. So an else was added.

## Changes

<!-- List any and all changes here, in bullet point form. -->

Here is the added code:

```powershell
if ($Stream.ReadByte() -eq 65) {
    ...
} else {
    $Stream.BaseStream.Position = 0
}
```

## Checklist

- [X] Pull Request has a meaningful title.
- [X] Summarised changes.
- [X] Pull Request is ready to merge & is not WIP.
- [X] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [X] Added documentation / opened issue to track adding documentation at a later date.
