### PR TITLE
Add Disconnect-SteamAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ for server information and more.
 | Cmdlet                                                   | Description                                                         |
 | -------------------------------------------------------- | ------------------------------------------------------------------- |
 | [Connect-SteamAPI](docs/Connect-SteamAPI.md)             | Create or update the Steam Web API config file.                     |
+| [Disconnect-SteamAPI](docs/Disconnect-SteamAPI.md)          | Disconnects from the Steam API by removing the stored API key.      |
 | [Find-SteamAppID](docs/Find-SteamAppID.md)               | Find a Steam AppID by searching the name of the application.        |
 | [Get-SteamFriendList](docs/Get-SteamFriendList.md)       | Returns the friend list of any Steam user.                          |
 | [Get-SteamNews](docs/Get-SteamNews.md)                   | Returns the latest news of a game specified by its AppID.           |

--- a/SteamPS/Public/API/Disconnect-SteamAPI.ps1
+++ b/SteamPS/Public/API/Disconnect-SteamAPI.ps1
@@ -21,7 +21,7 @@
     None. Nothing is returned when calling Disconnect-SteamAPI.
 
     .NOTES
-    Author: sysgoblin (https://github.com/sysgoblin) and Frederik Hjorslev Nylander
+    Author: Frederik Hjorslev Nylander
 
     .LINK
     https://hjorslev.github.io/SteamPS/Disconnect-SteamAPI.html
@@ -43,6 +43,15 @@
             if (Test-Path -Path $SteamAPIKey) {
                 Remove-Item -Path $SteamAPIKey -Force
                 Write-Verbose -Message "$SteamAPIKey were deleted."
+            } else {
+                $Exception = [Exception]::new("Steam Web API configuration file not found in '$env:AppData\SteamPS\SteamPSKey.json'.")
+                $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $Exception,
+                    'SteamAPIKeyNotFound',
+                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                    $SteamPSKey
+                )
+                $PSCmdlet.ThrowTerminatingError($ErrorRecord)
             }
         }
     }

--- a/SteamPS/Public/API/Disconnect-SteamAPI.ps1
+++ b/SteamPS/Public/API/Disconnect-SteamAPI.ps1
@@ -1,0 +1,53 @@
+﻿function Disconnect-SteamAPI {
+    <#
+    .SYNOPSIS
+    Disconnects from the Steam API by removing the stored API key.
+
+    .DESCRIPTION
+    The Disconnect-SteamAPI cmdlet removes the stored Steam API key from the system. This effectively disconnects the current session from the Steam API.
+
+    .PARAMETER Force
+    When the Force switch is used, the cmdlet will skip the confirmation prompt and directly remove the API key.
+
+    .EXAMPLE
+    Disconnect-SteamAPI -Force
+
+    This command will remove the stored Steam API key without asking for confirmation.
+
+    .INPUTS
+    None. You cannot pipe objects to Disconnect-SteamAPI.
+
+    .OUTPUTS
+    None. Nothing is returned when calling Disconnect-SteamAPI.
+
+    .NOTES
+    Author: sysgoblin (https://github.com/sysgoblin) and Frederik Hjorslev Nylander
+
+    .LINK
+    https://hjorslev.github.io/SteamPS/Disconnect-SteamAPI.html
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false,
+            HelpMessage = 'Skip the confirmation prompt.')][switch]$Force
+    )
+
+    begin {
+        Write-Verbose -Message "[BEGIN  ] Starting: $($MyInvocation.MyCommand)"
+        $SteamAPIKey = "$env:AppData\SteamPS\SteamPSKey.json"
+    }
+
+    process {
+        if ($Force -or $PSCmdlet.ShouldContinue($SteamAPIKey, 'Do you want to continue removing the API key?')) {
+            if (Test-Path -Path $SteamAPIKey) {
+                Remove-Item -Path $SteamAPIKey -Force
+                Write-Verbose -Message "$SteamAPIKey were deleted."
+            }
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[END    ] Ending: $($MyInvocation.MyCommand)"
+    }
+}

--- a/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
@@ -1,0 +1,12 @@
+﻿Describe 'Disconnect-SteamAPI' {
+    BeforeAll {
+        Mock -CommandName Test-Path -MockWith { return $true }
+        Mock -CommandName Remove-Item -MockWith {}
+    }
+
+    It 'removes the API key when -Force is used' {
+        Disconnect-SteamAPI -Force
+        Should -Invoke Test-Path -Times 1 -Scope It
+        Should -Invoke Remove-Item -Times 1 -Scope It
+    }
+}

--- a/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
@@ -1,24 +1,12 @@
-﻿Describe 'Disconnect-SteamAPI' {
-    Mock -ModuleName SteamPS Write-Verbose {} -Verifiable -ParameterFilter { $Message -eq "[BEGIN  ] Starting: $($MyInvocation.MyCommand)" }
-    Mock -ModuleName SteamPS Test-Path { return $true } -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
-    Mock -ModuleName SteamPS Remove-Item {} -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
-    Mock -ModuleName SteamPS Write-Verbose {} -Verifiable -ParameterFilter { $Message -eq "$SteamAPIKey were deleted." }
-    Mock -ModuleName SteamPS [Exception]::new {} -Verifiable -ParameterFilter { $Message -eq "Steam Web API configuration file not found in '$env:AppData\SteamPS\SteamPSKey.json'." }
-    Mock -ModuleName SteamPS [System.Management.Automation.ErrorRecord]::new {} -Verifiable -ParameterFilter { $CategoryInfo.Category -eq [System.Management.Automation.ErrorCategory]::ObjectNotFound }
-    Mock -ModuleName SteamPS $PSCmdlet.ThrowTerminatingError {} -Verifiable -ParameterFilter { $ErrorId -eq 'SteamAPIKeyNotFound' }
+﻿Describe 'Disconnect-SteamAPI Tests' {
+    BeforeAll {
+        Mock -ModuleName SteamPS Test-Path { return $true } -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+        Mock -ModuleName SteamPS Remove-Item {} -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+    }
 
     Context 'When Force is specified' {
         It 'Deletes the Steam API key file' {
-            $result = Disconnect-SteamAPI -Force
-            Should -InvokeVerifiable
-        }
-    }
-
-    Context 'When Force is not specified' {
-        Mock -ModuleName SteamPS $PSCmdlet.ShouldContinue { return $true }
-        It 'Deletes the Steam API key file' {
-            $result = Disconnect-SteamAPI
-            Should -InvokeVerifiable
+            Disconnect-SteamAPI -Force -Verbose | Should -InvokeVerifiable
         }
     }
 }

--- a/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
@@ -1,29 +1,24 @@
-﻿Describe 'Disconnect-SteamAPI Tests' {
-    Context 'With an API key' {
-        BeforeAll {
-            Mock -CommandName Test-Path -ModuleName SteamPS -MockWith {
-                return $true
-            }
-            Mock -CommandName Remove-Item -ModuleName SteamPS -MockWith {
-                return $true
-            }
-        }
-        It 'Should remove the API key when -Force is used' {
-            { Disconnect-SteamAPI -Force | Should -Not -Throw }
+﻿Describe 'Disconnect-SteamAPI' {
+    Mock -ModuleName SteamPS Write-Verbose {} -Verifiable -ParameterFilter { $Message -eq "[BEGIN  ] Starting: $($MyInvocation.MyCommand)" }
+    Mock -ModuleName SteamPS Test-Path { return $true } -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+    Mock -ModuleName SteamPS Remove-Item {} -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+    Mock -ModuleName SteamPS Write-Verbose {} -Verifiable -ParameterFilter { $Message -eq "$SteamAPIKey were deleted." }
+    Mock -ModuleName SteamPS [Exception]::new {} -Verifiable -ParameterFilter { $Message -eq "Steam Web API configuration file not found in '$env:AppData\SteamPS\SteamPSKey.json'." }
+    Mock -ModuleName SteamPS [System.Management.Automation.ErrorRecord]::new {} -Verifiable -ParameterFilter { $CategoryInfo.Category -eq [System.Management.Automation.ErrorCategory]::ObjectNotFound }
+    Mock -ModuleName SteamPS $PSCmdlet.ThrowTerminatingError {} -Verifiable -ParameterFilter { $ErrorId -eq 'SteamAPIKeyNotFound' }
+
+    Context 'When Force is specified' {
+        It 'Deletes the Steam API key file' {
+            $result = Disconnect-SteamAPI -Force
+            Should -InvokeVerifiable
         }
     }
 
-    Context 'Without an API key' {
-        BeforeAll {
-            Mock -CommandName Test-Path -ModuleName SteamPS -MockWith {
-                return $false
-            }
-            Mock -CommandName Remove-Item -ModuleName SteamPS -MockWith {
-                return $false
-            }
-        }
-        It 'Should fail when no API key is found' {
-            { Disconnect-SteamAPI -Force | Should -Throw }
+    Context 'When Force is not specified' {
+        Mock -ModuleName SteamPS $PSCmdlet.ShouldContinue { return $true }
+        It 'Deletes the Steam API key file' {
+            $result = Disconnect-SteamAPI
+            Should -InvokeVerifiable
         }
     }
 }

--- a/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
@@ -1,12 +1,29 @@
-﻿Describe 'Disconnect-SteamAPI' {
-    BeforeAll {
-        Mock -CommandName Test-Path -MockWith { return $true }
-        Mock -CommandName Remove-Item -MockWith {}
+﻿Describe 'Disconnect-SteamAPI Tests' {
+    Context 'With an API key' {
+        BeforeAll {
+            Mock -CommandName Test-Path -ModuleName SteamPS -MockWith {
+                return $true
+            }
+            Mock -CommandName Remove-Item -ModuleName SteamPS -MockWith {
+                return $true
+            }
+        }
+        It 'Should remove the API key when -Force is used' {
+            { Disconnect-SteamAPI -Force | Should -Not -Throw }
+        }
     }
 
-    It 'removes the API key when -Force is used' {
-        Disconnect-SteamAPI -Force
-        Should -Invoke Test-Path -Times 1 -Scope It
-        Should -Invoke Remove-Item -Times 1 -Scope It
+    Context 'Without an API key' {
+        BeforeAll {
+            Mock -CommandName Test-Path -ModuleName SteamPS -MockWith {
+                return $false
+            }
+            Mock -CommandName Remove-Item -ModuleName SteamPS -MockWith {
+                return $false
+            }
+        }
+        It 'Should fail when no API key is found' {
+            { Disconnect-SteamAPI -Force | Should -Throw }
+        }
     }
 }

--- a/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-SteamAPI.Tests.ps1
@@ -1,12 +1,11 @@
 ﻿Describe 'Disconnect-SteamAPI Tests' {
-    BeforeAll {
-        Mock -ModuleName SteamPS Test-Path { return $true } -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
-        Mock -ModuleName SteamPS Remove-Item {} -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
-    }
-
-    Context 'When Force is specified' {
+    Context 'When Force is specified and API key is found' {
+        BeforeAll {
+            Mock -CommandName Test-Path -ModuleName SteamPS -MockWith { return $true } -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+            Mock -CommandName Remove-Item -ModuleName SteamPS -MockWith {} -Verifiable -ParameterFilter { $Path -eq "$env:AppData\SteamPS\SteamPSKey.json" }
+        }
         It 'Deletes the Steam API key file' {
-            Disconnect-SteamAPI -Force -Verbose | Should -InvokeVerifiable
+            Disconnect-SteamAPI -Force | Should -InvokeVerifiable
         }
     }
 }

--- a/docs/Disconnect-SteamAPI.md
+++ b/docs/Disconnect-SteamAPI.md
@@ -1,0 +1,79 @@
+---
+external help file: SteamPS-help.xml
+Module Name: SteamPS
+online version: https://hjorslev.github.io/SteamPS/Disconnect-SteamAPI.html
+schema: 2.0.0
+---
+
+# Disconnect-SteamAPI
+
+## SYNOPSIS
+Disconnects from the Steam API by removing the stored API key.
+
+## SYNTAX
+
+```
+Disconnect-SteamAPI [-Force] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Disconnect-SteamAPI cmdlet removes the stored Steam API key from the system.
+This effectively disconnects the current session from the Steam API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Disconnect-SteamAPI -Force
+```
+
+This command will remove the stored Steam API key without asking for confirmation.
+
+## PARAMETERS
+
+### -Force
+When the Force switch is used, the cmdlet will skip the confirmation prompt and directly remove the API key.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Disconnect-SteamAPI.
+## OUTPUTS
+
+### None. Nothing is returned when calling Disconnect-SteamAPI.
+## NOTES
+Author: Frederik Hjorslev Nylander
+
+## RELATED LINKS
+
+[https://hjorslev.github.io/SteamPS/Disconnect-SteamAPI.html](https://hjorslev.github.io/SteamPS/Disconnect-SteamAPI.html)
+


### PR DESCRIPTION
## Description

Add cmdlet that allows one to disconnect the SteamAPI by removing the stored API key.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Pester tests that covers the added cmdlets