### PR TITLE
Add Test-Admin (private cmdlet)

### DIFF
--- a/SteamPS/Private/Server/Test-Admin.ps1
+++ b/SteamPS/Private/Server/Test-Admin.ps1
@@ -1,0 +1,50 @@
+function Test-Admin {
+    <#
+    .SYNOPSIS
+    Checks whether the current user has administrator privileges.
+
+    .DESCRIPTION
+    This cmdlet verifies if the current user has administrator privileges on the system.
+
+    .EXAMPLE
+    PS C:\> Test-Admin
+    True
+    This example checks if the current user has administrator privileges and returns True if they do.
+
+    .NOTES
+    Author: Marius Storhaug <https://github.com/PSModule/Admin>
+    #>
+
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    [Alias('Test-Administrator', 'IsAdmin', 'IsAdministrator')]
+    param (
+    )
+
+    begin {
+        Write-Verbose -Message "[BEGIN  ] Starting: $($MyInvocation.MyCommand)"
+    }
+
+    process {
+        $IsUnix = $PSVersionTable.Platform -eq 'Unix'
+        if ($IsUnix) {
+            Write-Verbose -Message "Running on Unix, checking if user is root."
+            $whoAmI = $(whoami)
+            Write-Verbose -Message "whoami: $whoAmI"
+            $IsRoot = $whoAmI -eq 'root'
+            Write-Verbose -Message "IsRoot: $IsRoot"
+            $IsRoot
+        } else {
+            Write-Verbose -Message "Running on Windows, checking if user is an Administrator."
+            $User = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $Principal = New-Object Security.Principal.WindowsPrincipal($User)
+            $isAdmin = $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+            Write-Verbose -Message "IsAdmin: $isAdmin"
+            $isAdmin
+        }
+    }
+
+    end {
+        Write-Verbose -Message "[END    ] Ending: $($MyInvocation.MyCommand)"
+    }
+}

--- a/Tests/Unit/Private/Test-Admin.Tests.ps1
+++ b/Tests/Unit/Private/Test-Admin.Tests.ps1
@@ -1,0 +1,28 @@
+﻿BeforeAll {
+    . $SteamPSModulePath\Private\Server\Test-Admin.ps1
+}
+
+Describe 'Test-Admin Tests' {
+    Context 'Function: Test-Admin' {
+        It 'Should not throw' {
+            { Test-Admin } | Should -Not -Throw
+        }
+
+        It 'Should return <Expected> for <OS> based runners' -ForEach @(
+            @{
+                Expected = if ($IsLinux -or $IsMacOS) {
+                    $false
+                } else {
+                    $true
+                }
+                OS       = if ($IsLinux -or $IsMacOS) {
+                    'Unix'
+                } else {
+                    'Windows'
+                }
+            }
+        ) {
+            Test-Admin | Should -Be $Expected
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add cmdlet that can be used to test if current user is an admin.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] ⚠️ [Security fix]
- [x] ♻️ [Refactor]
- [ ] 🎉 [Feature]
- [ ] ✨ Enhancement
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Pester tests that covers the added cmdlets