### PR TITLE
Change param validation to verbose output

### DIFF
--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -70,7 +70,7 @@ function Update-SteamApp {
         )]
         [ValidateScript({
             if ($null -eq (Get-SteamApp -ApplicationID $_)) {
-                    Write-Warning -Message "ApplicationID $_ couldn't be found in the Steam application list. Continuing anyway as the application might exist."
+                    Write-Warning -Message "ApplicationID $_ couldn't be found using the Steam Web API. Continuing anyway as the application might exist."
             }
             $true
         })]

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -34,7 +34,7 @@ function Update-SteamApp {
     .EXAMPLE
     Update-SteamApp -ApplicationName 'Arma 3' -Credential 'Toby' -Path 'C:\DedicatedServers\Arma3'
 
-    Because there are multiple hits when searching for Arma 3, the user will be promoted to select the right application.
+    Because there are multiple hits when searching for Arma 3, the user will be promted to select the right application.
 
     .EXAMPLE
     Update-SteamApp -AppID 376030 -Path 'C:\DedicatedServers\ARK-SurvivalEvolved'

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -70,7 +70,7 @@ function Update-SteamApp {
         )]
         [ValidateScript({
             if ($null -eq (Get-SteamApp -ApplicationID $_)) {
-                    Write-Warning -Message "ApplicationID $_ couldn't be found using the Steam Web API. Continuing anyway as the application might exist."
+                    Write-Verbose -Message "ApplicationID $_ couldn't be found using the Steam Web API. Continuing anyway as the application might exist."
             }
             $true
         })]

--- a/SteamPS/Public/Server/Update-SteamApp.ps1
+++ b/SteamPS/Public/Server/Update-SteamApp.ps1
@@ -70,7 +70,7 @@ function Update-SteamApp {
         )]
         [ValidateScript({
             if ($null -eq (Get-SteamApp -ApplicationID $_)) {
-                throw "ApplicationID $_ couldn't be found."
+                    Write-Warning -Message "ApplicationID $_ couldn't be found in the Steam application list. Continuing anyway as the application might exist."
             }
             $true
         })]


### PR DESCRIPTION
## Description

Fixes #97 

Change the parameter validation to just show a verbose output if the application isn't found instead of throwing an error.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] ⚠️ [Security fix]
- [ ] ♻️ [Refactor]
- [ ] 🎉 [Feature]
- [ ] ✨ Enhancement
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added Pester tests that covers the added cmdlets