### PR TITLE
Add Ping measurement to Get-SteamServerInfo

### DIFF
--- a/SteamPS/Public/Server/Get-SteamServerInfo.ps1
+++ b/SteamPS/Public/Server/Get-SteamServerInfo.ps1
@@ -38,6 +38,7 @@
     ExtraDataFlag : 177
     IPAddress     : 185.15.73.207
     Port          : 27015
+    Ping          : 65
     ```
 
     .NOTES
@@ -72,13 +73,15 @@
         try {
             # Instantiate client and endpoint
             $Client = New-Object -TypeName Net.Sockets.UDPClient(0)
-            [void]$Client.Send($A2S_INFO, $A2S_INFO.Length, $IPAddress, $Port)
             $Client.Client.SendTimeout = $Timeout
             $Client.Client.ReceiveTimeout = $Timeout
             $IPEndpoint = New-Object -TypeName Net.IPEndpoint([Net.IPAddress]::Any, 0)
+            $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            [void]$Client.Send($A2S_INFO, $A2S_INFO.Length, $IPAddress, $Port)
 
             # The first 4 bytes are 255 which seems to be some sort of header.
             $ReceivedData = $Client.Receive([Ref]$IPEndpoint) | Select-Object -Skip 4
+            $Ping = $Stopwatch.ElapsedMilliseconds
             $Stream = [System.IO.BinaryReader][System.IO.MemoryStream][Byte[]]$ReceivedData
 
             # Challenge:
@@ -131,6 +134,7 @@
                 ExtraDataFlag = $Stream.ReadByte()
                 IPAddress     = $IPAddress
                 Port          = $Port
+                Ping          = $Ping
             } # PSCustomObject
         }
     } # Process

--- a/Tests/Integration/Public/Get-SteamServerInfo.Tests.ps1
+++ b/Tests/Integration/Public/Get-SteamServerInfo.Tests.ps1
@@ -21,6 +21,7 @@
                     ExtraDataFlag = 177
                     IPAddress     = "135.239.211.40"
                     Port          = 27015
+                    Ping          = 65
                 }
             }
 
@@ -44,6 +45,7 @@
             $result.Version | Should -Be "1.0.0.0"
             $result.IPAddress | Should -Be "135.239.211.40"
             $result.Port | Should -Be 27015
+            $result.Ping | Should -Be 65
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds Ping measurement to Get-SteamServerInfo as described in #100 

Resolves #100 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] ⚠️ [Security fix]
- [ ] ♻️ [Refactor]
- [ ] 🎉 [Feature]
- [x] ✨ Enhancement
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Pester tests that covers the added cmdlets